### PR TITLE
Add OPML support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ringfairy"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -20,6 +20,7 @@ serde_json = "1.0"
 tera = "1.19"
 tokio = { version = "1", features = ["full"] }
 url = "2.5"
+opml = "1.1.6"
 
 [profile.release]
 lto = true

--- a/config.json
+++ b/config.json
@@ -1,10 +1,13 @@
 {
-  "ring_name": "YOUR_RING_NAME",
+  "ring_name": "Webring",
+  "ring_description": "A webring to connect member sites.",
+  "ring_owner": "Webring Organization / Person",
+  "ring_owner_site": "https://domain.tld",
   "filepath_list": "./websites.json",
   "path_output": "./webring",
   "path_assets": "./data/assets",
   "path_templates": "./data/templates",
-  "base_url": "https://YOUR-DOMAIN.com",
+  "base_url": "https://webring.domain.tld",
   "shuffle": false,
   "verbose": false,
   "skip_minify": false

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "ring_name": "YOUR_RING_NAME",
   "filepath_list": "./websites.json",
   "path_output": "./webring",
   "path_assets": "./data/assets",

--- a/data/templates/list.html
+++ b/data/templates/list.html
@@ -2,22 +2,22 @@
 
 <!DOCTYPE html>
 <html lang="en">
-<link rel="stylesheet" href="./styles.css">
-<head>
+  <link rel="stylesheet" href="./styles.css">
+  <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Webring List</title>
-</head>
-<body>
+  </head>
+  <body>
     <h1>Webring List</h1>
     <p>Add all sites with declared RSS feeds to your feed reader with this <a href ="{{ opml }}">OPML</a> link.</p>
     {{ table_of_sites | safe}}
 
 
-<br>
-<footer>
-<p>Last updated: {{ current_time }} </p>
-<p>Powered by ringfairy!</p>
-</footer>
-</body>
+	<br>
+	<footer>
+	  <p>Last updated: {{ current_time }} </p>
+	  <p>Powered by ringfairy!</p>
+	</footer>
+  </body>
 </html>

--- a/data/templates/list.html
+++ b/data/templates/list.html
@@ -10,7 +10,7 @@
 </head>
 <body>
     <h1>Webring List</h1>
-
+    <p>Add all sites with declared RSS feeds to your feed reader with this <a href ="{{ opml }}">OPML</a> link.</p>
     {{ table_of_sites | safe}}
 
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,9 @@ use crate::file;
 #[derive(Debug)]
 pub struct AppSettings {
     pub ring_name: String,
+    pub ring_description: String,
+    pub ring_owner: String,
+    pub ring_owner_site: String,
     pub filepath_config: String,
     pub filepath_list: String,
     pub path_output: String,
@@ -26,7 +29,10 @@ pub struct AppSettings {
 impl Default for AppSettings {
     fn default() -> Self {
         AppSettings {
-            ring_name: "./config.json".into(),
+            ring_name: "webring".into(),
+            ring_description: "A ring that connects websites to each other with links".into(),
+            ring_owner: "Webring Organization or Person".into(),
+            ring_owner_site: "https://webring.domain.tld/".into(),
             filepath_config: "./config.json".into(),
             filepath_list: "./websites.json".into(),
             path_output: "./webring".into(),
@@ -48,6 +54,9 @@ impl Default for AppSettings {
 #[derive(Deserialize, Debug)]
 pub struct ConfigSettings {
     pub ring_name: Option<String>,
+    pub ring_description: Option<String>,
+    pub ring_owner: Option<String>,
+    pub ring_owner_site: Option<String>,
     pub filepath_list: Option<String>,
     pub path_output: Option<String>,
     pub path_assets: Option<String>,
@@ -172,6 +181,9 @@ fn merge_configs(cli_args: ClapSettings, config: Option<ConfigSettings>) -> AppS
     if let Some(conf) = config {
         // Apply settings from config.json where available (unwrap_or keeps original if None)
         final_settings.ring_name = conf.ring_name.unwrap_or(final_settings.ring_name);
+        final_settings.ring_description = conf.ring_description.unwrap_or(final_settings.ring_description);
+        final_settings.ring_owner = conf.ring_owner.unwrap_or(final_settings.ring_owner);
+        final_settings.ring_owner_site = conf.ring_owner_site.unwrap_or(final_settings.ring_owner_site);
         final_settings.filepath_list = conf.filepath_list.unwrap_or(final_settings.filepath_list);
         final_settings.path_output = conf.path_output.unwrap_or(final_settings.path_output);
         final_settings.path_assets = conf.path_assets.unwrap_or(final_settings.path_assets);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use crate::file;
 // Main/final settings struct
 #[derive(Debug)]
 pub struct AppSettings {
+    pub ring_name: String,
     pub filepath_config: String,
     pub filepath_list: String,
     pub path_output: String,
@@ -25,6 +26,7 @@ pub struct AppSettings {
 impl Default for AppSettings {
     fn default() -> Self {
         AppSettings {
+            ring_name: "./config.json".into(),
             filepath_config: "./config.json".into(),
             filepath_list: "./websites.json".into(),
             path_output: "./webring".into(),
@@ -45,6 +47,7 @@ impl Default for AppSettings {
 // Contains settings loaded from config file, e.g., config.json
 #[derive(Deserialize, Debug)]
 pub struct ConfigSettings {
+    pub ring_name: Option<String>,
     pub filepath_list: Option<String>,
     pub path_output: Option<String>,
     pub path_assets: Option<String>,
@@ -168,6 +171,7 @@ fn merge_configs(cli_args: ClapSettings, config: Option<ConfigSettings>) -> AppS
 
     if let Some(conf) = config {
         // Apply settings from config.json where available (unwrap_or keeps original if None)
+        final_settings.ring_name = conf.ring_name.unwrap_or(final_settings.ring_name);
         final_settings.filepath_list = conf.filepath_list.unwrap_or(final_settings.filepath_list);
         final_settings.path_output = conf.path_output.unwrap_or(final_settings.path_output);
         final_settings.path_assets = conf.path_assets.unwrap_or(final_settings.path_assets);

--- a/src/html.rs
+++ b/src/html.rs
@@ -72,8 +72,9 @@ impl HtmlGenerator {
 
         let mut opml = OPML::default();
         opml.head = Some(Head {
-            title: Some("Craftering: System Crafters Community Webring".to_string()),
-            owner_name: Some("System Crafters Community".to_string()),
+            title: Some(settings.ring_description.to_owned()),
+            owner_name: Some(settings.ring_owner.to_owned()),
+            owner_id: Some(settings.ring_owner_site.to_owned()),
             ..Head::default()
         });
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use tera::{Context, Tera};
 
 use opml::*;
-use crate::website::Website;
 use crate::cli::AppSettings;
 
 //use crate::file::acquire_file_data;
@@ -79,7 +78,7 @@ impl HtmlGenerator {
             ..Head::default()
         });
 
-        for (index, website) in webring.iter().enumerate() {
+        for (_index, website) in webring.iter().enumerate() {
             if let Some(owner) = &website.website.owner {
                 if let Some(rss_url) = website.website.rss.as_ref().filter(|url| !url.is_empty()) {
                     opml.add_feed(owner, rss_url);

--- a/src/website.rs
+++ b/src/website.rs
@@ -62,6 +62,11 @@ pub async fn process_websites(settings: &AppSettings) -> Result<(), Box<dyn std:
             .await?;
 
         log::info!("Finished generating webring HTML.");
+
+        log::info!("Generating OPML file...");
+        html_generator
+            .generate_opml(&webring, &settings)
+            .await?;
     }
 
     Ok(())

--- a/src/website.rs
+++ b/src/website.rs
@@ -58,7 +58,7 @@ pub async fn process_websites(settings: &AppSettings) -> Result<(), Box<dyn std:
         log::info!("Generating websites HTML...");
 
         html_generator
-            .generate_html(&webring, &settings.path_output)
+            .generate_html(&webring, &settings)
             .await?;
 
         log::info!("Finished generating webring HTML.");


### PR DESCRIPTION
Outline Processor Markup Language ([OPML](http://opml.org/spec2.opml)) is a popular format for exchanging subscription lists between readers and aggregators.

Since a webring is a collection of sites that someone might want to subscribe to as a whole. Ringfairy already exposes the RSS feed link when provided, it would make sense to be able to subscribe to the whole ring with a single convenient list instead of individually.

The sites are only added to the OPML list if a RSS entry is found and it respects the `audit` setting.